### PR TITLE
Update hash function for STL containers

### DIFF
--- a/include/nonstd/observer_ptr.hpp
+++ b/include/nonstd/observer_ptr.hpp
@@ -406,7 +406,7 @@ namespace std
 template< class T >
 struct hash< ::nonstd::observer_ptr<T> >
 {
-    size_t operator()(::nonstd::observer_ptr<T> p ) { return hash<T*>()( p.get() ); }
+    size_t operator()(::nonstd::observer_ptr<T> p ) const { return hash<T*>()( p.get() ); }
 };
 
 }


### PR DESCRIPTION
The current hash specialization is not const-qualified and therefore certain STL containers will fail to compile as they hold an immutable reference to the hash.